### PR TITLE
fix: update autocomplete attributes for email and password fields

### DIFF
--- a/web/src/pages/@modals/useAuthSignUpModal/Component.tsx
+++ b/web/src/pages/@modals/useAuthSignUpModal/Component.tsx
@@ -103,7 +103,7 @@ export const Component = ({ portal }: ComponentProps) => {
                   id="email"
                   name="email"
                   type="email"
-                  autoComplete="email"
+                  autoComplete="off"
                   label={getRequiredLabel('Correo electrónico')}
                   className="mt-6"
                 />
@@ -113,7 +113,7 @@ export const Component = ({ portal }: ComponentProps) => {
                     id="password"
                     name="password"
                     type="password"
-                    autoComplete="password"
+                    autoComplete="new-password"
                     label={getRequiredLabel('Contraseña')}
                     className="mt-6"
                   />

--- a/web/src/pages/@modals/useAuthSignUpModal/Component.tsx
+++ b/web/src/pages/@modals/useAuthSignUpModal/Component.tsx
@@ -103,7 +103,7 @@ export const Component = ({ portal }: ComponentProps) => {
                   id="email"
                   name="email"
                   type="email"
-                  autoComplete="off"
+                  autoComplete="email"
                   label={getRequiredLabel('Correo electrónico')}
                   className="mt-6"
                 />


### PR DESCRIPTION
## Fix: Prevent Password Autocomplete on New User Creation

This Pull Request addresses an issue where the password input field in the new user creation form was incorrectly suggesting saved passwords. This behavior is unintended and poses a security risk, as well as potentially confusing users. The goal of this PR is to ensure that when the new user creation form is displayed, the password input fields are empty and do not suggest previously saved passwords.

### Changes Made

- **File Modified**: `Component.tsx`
- **Lines**: 97 to 121

The specific change involves adjusting the `autoComplete` attribute for the password input field:

```tsx
<FieldInput
  id="password"
  name="password"
  type="password"
  autoComplete="new-password" // Ensures browsers treat this as a new password, not suggesting saved ones
  label={getRequiredLabel('Contraseña')}
  className="mt-6"
/>